### PR TITLE
Remove leading \n in config.txt

### DIFF
--- a/sd-image.nix
+++ b/sd-image.nix
@@ -31,7 +31,8 @@
             config=firmware/config.txt
             # The initial file has just been created without write permissions. Add them to be able to append the file.
             chmod u+w $config
-            echo "\n# Extra configuration" >> $config
+            echo "" >> $config
+            echo "# Extra configuration" >> $config
             echo "${extraFirmwareConfigString}" >> $config
             chmod u-w $config
           ''


### PR DESCRIPTION
This fix a little syntax issue in `config.txt` The rpi doesn't seem to bother tho.

Before:
```
# Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
# when attempting to show low-voltage or overtemperature warnings.
avoid_warnings=1
\n# Extra configuration
gpu_mem=16
hdmi_group=2
hdmi_mode=8
start_x=0
```

After:
```
# Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
# when attempting to show low-voltage or overtemperature warnings.
avoid_warnings=1

# Extra configuration
gpu_mem=16
hdmi_group=2
hdmi_mode=8
start_x=0
```