### PR TITLE
Add support for creating a link local address

### DIFF
--- a/zero2w.nix
+++ b/zero2w.nix
@@ -127,7 +127,7 @@
   services.getty.autologinUser = "bob";
 
   # ! change the host name if you like
-  networking.hostName = "remote";
+  networking.hostName = "pi";
 
   services.avahi = {
     enable = true;


### PR DESCRIPTION
This pr adds configuration for avahi to create a link local address like how you can in rpi flasher. The pi will be accessible through the address [hostname].local. This allows the user to connect to the pi over ssh without having to first check the ip. 