### PR TITLE
modularize the flake to allow cleaner separate use of the sd-card and hardware configuration in existing flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,38 @@
 # Building a NixOS SD image for a Raspberry Pi Zero 2 w
 
+## Usage
+
+### With an existing flake setup
+
+Add the falke into the inputs:
+```nix
+  inputs = {
+    nixos-pi-zero-2 = {
+      url = "github:plmercereau/nixos-pi-zero-2";
+    };
+  };
+```
+
+Use it in the outputs:
+
+```nix
+  outputs = {}: {
+    nixosConfigurations = {
+      zero2w = nixpkgs.lib.nixosSystem {
+        modules = [
+          nixos-pi-zero-2.nixosModules.sd-image
+          nixos-pi-zero-2.nixosModules.hardware
+          {
+            # Configure your machine here. Head to zero2w.nix for opiniotaned defaults.
+          }
+        ];
+      };
+    };
+  };
+```
+
+### On its own
+
 1. Update `zero2w.nix`
 
 In particular, don't forget:

--- a/flake.lock
+++ b/flake.lock
@@ -72,16 +72,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1744440957,
-        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
+        "lastModified": 1771208521,
+        "narHash": "sha256-X01Q3DgSpjeBpapoGA4rzKOn25qdKxbPnxHeMLNoHTU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
+        "rev": "fa56d7d6de78f5a7f997b0ea2bc6efd5868ad9e8",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -7,46 +7,53 @@
     deploy-rs.url = "github:serokell/deploy-rs";
   };
 
-  outputs = inputs: 
+  outputs =
+    inputs:
     with inputs;
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = nixpkgs.legacyPackages."${system}";
-      crossPkgs = import "${nixpkgs}" {
-        localSystem = system;
-        crossSystem = "aarch64-linux";
-      };
-    in rec {
-      nixosConfigurations = {
-        zero2w = nixpkgs.lib.nixosSystem {
-          modules = [
-            "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
-            ./zero2w.nix
-            {
-              nixpkgs.pkgs = crossPkgs; # configure cross compilation. If the build system `system` is aarch64, this will provide the aarch64 nixpkgs
-            }
-          ];
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages."${system}";
+        crossPkgs = import "${nixpkgs}" {
+          localSystem = system;
+          crossSystem = "aarch64-linux";
         };
-      };
-
-      deploy = {
-        user = "root";
-        nodes = {
-          zero2w = {
-            hostname = "zero2w";
-            profiles.system.path =
-              deploy-rs.lib.aarch64-linux.activate.nixos self.nixosConfigurations.zero2w;
+      in
+      rec {
+        nixosConfigurations = {
+          zero2w = nixpkgs.lib.nixosSystem {
+            modules = [
+              "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
+              ./zero2w.nix
+              {
+                nixpkgs.pkgs = crossPkgs; # configure cross compilation. If the build system `system` is aarch64, this will provide the aarch64 nixpkgs
+              }
+            ];
           };
         };
-      };
-    }) // {
-      nixosModules.sd-image = {inputs, ...}: {
-        imports = [
-           "${inputs.nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
-          ./sd-image.nix
-          ./sd-defaults.nix
-        ];
-      };
 
-      nixosModules.hardware = ./hardware.nix
+        deploy = {
+          user = "root";
+          nodes = {
+            zero2w = {
+              hostname = "zero2w";
+              profiles.system.path = deploy-rs.lib.aarch64-linux.activate.nixos self.nixosConfigurations.zero2w;
+            };
+          };
+        };
+      }
+    )
+    // {
+      nixosModules.sd-image =
+        { inputs, ... }:
+        {
+          imports = [
+            "${inputs.nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
+            ./sd-image.nix
+            ./sd-defaults.nix
+          ];
+        };
+
+      nixosModules.hardware = ./hardware.nix;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,19 +2,19 @@
   description = "Flake for building a Raspberry Pi Zero 2 SD image";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
     deploy-rs.url = "github:serokell/deploy-rs";
   };
 
   outputs = inputs: 
-   with inputs;
-      flake-utils.lib.eachDefaultSystem (system: let
-        pkgs = nixpkgs.legacyPackages."${system}";
-        crossPkgs = import "${nixpkgs}" { 
-          localSystem = system;
-          crossSystem = "aarch64-linux";
-        };
+    with inputs;
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages."${system}";
+      crossPkgs = import "${nixpkgs}" {
+        localSystem = system;
+        crossSystem = "aarch64-linux";
+      };
     in rec {
       nixosConfigurations = {
         zero2w = nixpkgs.lib.nixosSystem {
@@ -38,6 +38,15 @@
           };
         };
       };
-    }
-  );
+    }) // {
+      nixosModules.sd-image = {inputs, ...}: {
+        imports = [
+           "${inputs.nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
+          ./sd-image.nix
+          ./sd-defaults.nix
+        ];
+      };
+
+      nixosModules.hardware = ./hardware.nix
+    };
 }

--- a/hardware.nix
+++ b/hardware.nix
@@ -1,0 +1,60 @@
+{pkgs, lib, ...}:{
+  # Some packages (ahci fail... this bypasses that) https://discourse.nixos.org/t/does-pkgs-linuxpackages-rpi3-build-all-required-kernel-modules/42509
+  nixpkgs.overlays = [
+    (final: super: {
+      makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
+    })
+  ];
+
+  nixpkgs.hostPlatform = "aarch64-linux";
+
+  zramSwap = {
+    enable = true;
+    algorithm = "zstd";
+  };
+
+  hardware = {
+    enableRedistributableFirmware = lib.mkForce false;
+    firmware = [ pkgs.raspberrypiWirelessFirmware ]; # Keep this to make sure wifi works
+    i2c.enable = true;
+
+    deviceTree = {
+      enable = true;
+      kernelPackage = pkgs.linuxKernel.packages.linux_rpi3.kernel;
+      filter = "*2837*";
+
+      overlays = [
+        {
+          name = "enable-i2c";
+          dtsFile = ./dts/i2c.dts;
+        }
+        {
+          name = "pwm-2chan";
+          dtsFile = ./dts/pwm.dts;
+        }
+        {
+          name = "spi1-2cs";
+          dtsFile = ./dts/spi.dts;
+        }
+      ];
+    };
+  };
+
+  boot = {
+    kernelPackages = pkgs.linuxPackages_rpi02w;
+
+    initrd.availableKernelModules = [
+      "xhci_pci"
+      "usbhid"
+      "usb_storage"
+    ];
+    loader = {
+      grub.enable = false;
+      generic-extlinux-compatible.enable = true;
+    };
+
+    # Avoids warning: mdadm: Neither MAILADDR nor PROGRAM has been set. This will cause the `mdmon` service to crash.
+    # See: https://github.com/NixOS/nixpkgs/issues/254807
+    swraid.enable = lib.mkForce false;
+  };
+}

--- a/hardware.nix
+++ b/hardware.nix
@@ -1,4 +1,5 @@
-{pkgs, lib, ...}:{
+{ pkgs, lib, ... }:
+{
   # Some packages (ahci fail... this bypasses that) https://discourse.nixos.org/t/does-pkgs-linuxpackages-rpi3-build-all-required-kernel-modules/42509
   nixpkgs.overlays = [
     (final: super: {

--- a/sd-defaults.nix
+++ b/sd-defaults.nix
@@ -1,0 +1,20 @@
+{...}: {
+  image.fileName = "zero2.img";
+  sdImage = {
+    # bzip2 compression takes loads of time with emulation, skip it. Enable this if you're low on space.
+    compressImage = false;
+
+    extraFirmwareConfig = {
+      # Give up VRAM for more Free System Memory
+      # - Disable camera which automatically reserves 128MB VRAM
+      start_x = 0;
+      # - Reduce allocation of VRAM to 16MB minimum for non-rotated (32MB for rotated)
+      gpu_mem = 16;
+
+      # Configure display to 800x600 so it fits on most screens
+      # * See: https://elinux.org/RPi_Configuration
+      hdmi_group = 2;
+      hdmi_mode = 8;
+    };
+  };
+}

--- a/sd-defaults.nix
+++ b/sd-defaults.nix
@@ -1,4 +1,5 @@
-{...}: {
+{ ... }:
+{
   image.fileName = "zero2.img";
   sdImage = {
     # bzip2 compression takes loads of time with emulation, skip it. Enable this if you're low on space.

--- a/sd-image.nix
+++ b/sd-image.nix
@@ -5,11 +5,12 @@
   lib,
   pkgs,
   ...
-}: {
+}:
+{
   options.sdImage = with lib; {
     extraFirmwareConfig = mkOption {
       type = types.attrs;
-      default = {};
+      default = { };
       description = lib.mdDoc ''
         Extra configuration to be added to config.txt.
       '';
@@ -19,15 +20,14 @@
   config = {
     sdImage.populateFirmwareCommands =
       lib.mkIf ((lib.length (lib.attrValues config.sdImage.extraFirmwareConfig)) > 0)
-      (
-        let
-          # Convert the set into a string of lines of "key=value" pairs.
-          keyValueMap = name: value: name + "=" + toString value;
-          keyValueList = lib.mapAttrsToList keyValueMap config.sdImage.extraFirmwareConfig;
-          extraFirmwareConfigString = lib.concatStringsSep "\n" keyValueList;
-        in
-          lib.mkAfter
-          ''
+        (
+          let
+            # Convert the set into a string of lines of "key=value" pairs.
+            keyValueMap = name: value: name + "=" + toString value;
+            keyValueList = lib.mapAttrsToList keyValueMap config.sdImage.extraFirmwareConfig;
+            extraFirmwareConfigString = lib.concatStringsSep "\n" keyValueList;
+          in
+          lib.mkAfter ''
             config=firmware/config.txt
             # The initial file has just been created without write permissions. Add them to be able to append the file.
             chmod u+w $config
@@ -36,6 +36,6 @@
             echo "${extraFirmwareConfigString}" >> $config
             chmod u-w $config
           ''
-      );
+        );
   };
 }

--- a/zero2w.nix
+++ b/zero2w.nix
@@ -1,94 +1,14 @@
-{
-  lib,
-  modulesPath,
-  pkgs,
-  ...
-}:
+{ ... }:
 {
   imports = [
     ./sd-image.nix
+    ./sd-defaults.nix
+    ./hardware.nix
   ];
 
-  # Some packages (ahci fail... this bypasses that) https://discourse.nixos.org/t/does-pkgs-linuxpackages-rpi3-build-all-required-kernel-modules/42509
-  nixpkgs.overlays = [
-    (final: super: {
-      makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
-    })
-  ];
-
-  nixpkgs.hostPlatform = "aarch64-linux";
   # ! Need a trusted user for deploy-rs.
   nix.settings.trusted-users = [ "@wheel" ];
-  system.stateVersion = "24.05";
-
-  zramSwap = {
-    enable = true;
-    algorithm = "zstd";
-  };
-
-  sdImage = {
-    # bzip2 compression takes loads of time with emulation, skip it. Enable this if you're low on space.
-    compressImage = false;
-    imageName = "zero2.img";
-
-    extraFirmwareConfig = {
-      # Give up VRAM for more Free System Memory
-      # - Disable camera which automatically reserves 128MB VRAM
-      start_x = 0;
-      # - Reduce allocation of VRAM to 16MB minimum for non-rotated (32MB for rotated)
-      gpu_mem = 16;
-
-      # Configure display to 800x600 so it fits on most screens
-      # * See: https://elinux.org/RPi_Configuration
-      hdmi_group = 2;
-      hdmi_mode = 8;
-    };
-  };
-
-  hardware = {
-    enableRedistributableFirmware = lib.mkForce false;
-    firmware = [ pkgs.raspberrypiWirelessFirmware ]; # Keep this to make sure wifi works
-    i2c.enable = true;
-
-    deviceTree = {
-      enable = true;
-      kernelPackage = pkgs.linuxKernel.packages.linux_rpi3.kernel;
-      filter = "*2837*";
-
-      overlays = [
-        {
-          name = "enable-i2c";
-          dtsFile = ./dts/i2c.dts;
-        }
-        {
-          name = "pwm-2chan";
-          dtsFile = ./dts/pwm.dts;
-        }
-        {
-          name = "spi1-2cs";
-          dtsFile = ./dts/spi.dts;
-        }
-      ];
-    };
-  };
-
-  boot = {
-    kernelPackages = pkgs.linuxPackages_rpi02w;
-
-    initrd.availableKernelModules = [
-      "xhci_pci"
-      "usbhid"
-      "usb_storage"
-    ];
-    loader = {
-      grub.enable = false;
-      generic-extlinux-compatible.enable = true;
-    };
-
-    # Avoids warning: mdadm: Neither MAILADDR nor PROGRAM has been set. This will cause the `mdmon` service to crash.
-    # See: https://github.com/NixOS/nixpkgs/issues/254807
-    swraid.enable = lib.mkForce false;
-  };
+  system.stateVersion = "25.11";
 
   networking = {
     interfaces."wlan0".useDHCP = true;


### PR DESCRIPTION
now provides nixosModules.sd-image (builds an image) and nixosModules.hardware (configures boot and hardware)

tested the following way:

original method builds (i use binfmt for aarch64 on my host system, so not cross compiled), boots, rpi is accessible via ssh
modularized one builds, boots, rpi is accessible via ssh when it is configured in the system

bumps nixpkgs to 25.11
includes nixfmt  in a separate commit 